### PR TITLE
Fix org_name XSS path

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,6 +188,7 @@ function about() {
     var chatt_mode = $.getUrlVar('chatt_mode');
     var china_mode = $.getUrlVar('china_mode');
     var dprk_mode = $.getUrlVar('dprk_mode');
+    var origin = $.getUrlVar('origin');
     var random_mode = $.getUrlVar('random_mode');
     var tng = $.getUrlVar('tng');
     var wargames = $.getUrlVar('wargames');
@@ -381,7 +382,7 @@ function about() {
              srccountry = cnlatlong[src]["country"];
            }
            // "Hi, Kim Jong!"
-           if (typeof dprk_mode !== 'undefined') {
+           else if (typeof dprk_mode !== 'undefined') {
              srclat = 39.0194;
              srclong = 125.7381;
              which_attack = "ZOMG NORTH KOREAZ!!!";
@@ -389,11 +390,27 @@ function about() {
            }
            // source is always Chattanooga if chatt_mode is set
            // "Hi ThreatStream!!" http://www.csoonline.com/article/2689609/network-security/threat-intelligence-firm-mistakes-research-for-nation-state-attack.html
-           if (typeof chatt_mode !== 'undefined') {
+           else if (typeof chatt_mode !== 'undefined') {
              srclat = 35.0456297;
              srclong = -85.30968;
              which_attack = "OMG NATION STATE CHATTANOOGA!!!";
              srccountry = "usa";
+           }
+
+           // Specify a country
+           else if (typeof origin !== 'undefined') {
+             srccountry = origin.toUpperCase();
+             var center_id = 0;
+             for (i = 0; i < centers.length; i ++) {
+               center_id = i;
+               if (centers[i].FIPS10 === srccountry) {
+                break;
+               }
+             }
+
+             srccountry = origin.toLowerCase();
+             srclat = centers[center_id].LAT;
+             srclong = centers[center_id].LONG;
            }
 
            hits.push( { origin : { latitude: +srclat, longitude: +srclong },


### PR DESCRIPTION
You can specify `origin=cc` where cc is a country code as listed in the centroids FIPS10 column, and attacks will originate from there. Only works if one of the `_mode` args is _not_ specified

before change, org name of `org_name=<script>alert(%27xss%27)</script>` creates an alert box, confirming XSS. Changed to use the `.text()` property for proper escaping, closes XSS hole.

see, e.g. http://darrenpmeyer.com/pewpew/?org_name=%3Cscript%3Ealert(%27xss%27)%3C/script%3E&origin=us
