### PR TITLE
adds blame a former employee mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ By default, IPew will use a statistical model for choosing source countries for 
 
 In similar vein, and using the perpsective many prominent security vendors and pundits seem to have, you can make all cyber attacks from from China with `china_mode=1` or from North Korea with `dprk_mode=1`.
 
+
 IPew's default attack timing is based on observational data from many sources, but you can make it look like the world is on the brink of cyber collapse by setting `bad_day=1`.
 
 Finally, you can proudly display your organization's name by setting `org_name=MyOrgName` (URL encode any spaces or special characters).
@@ -42,6 +43,13 @@ Finally, you can proudly display your organization's name by setting `org_name=M
 We had an interesting request to be able to use IPew in a IR "drill" setting, so there's now a "drill mode" where you can specify a latitude &amp; longitude to be the destination for the attacks. Right now, all attacks go there, but we may add an option to specify a percentage of attacks that should go there. You _must_ use `drill_mode=1&lat=##.####&lon=##.####` for this to work, like: `drill_mode=1&lat=43.2672&lon=-70.8617` (which would focus all attacks near @hrbrmstr). Remember, you can specify your organization name there, too. [Here's an example](http://ocularwarfare.com/ipew/index.html?org_name=hrbrmstr&drill_mode=1&lat=43.2672&lon=-70.8617).
 
 One of my personal favorites is [http://ocularwarfare.com/ipew/index.html?china_mode=1&org_name=Mandiant&bad_day=1](http://ocularwarfare.com/ipew/index.html?china_mode=1&org_name=Mandiant&bad_day=1).
+
+### Blame former employee mode
+
+If you want to show that former employees are the problem, try out
+employee_mode. You can set a first and last name for the employee and also
+set a latitude and longitude.
+[http://ocularwarfare.com/ipew/index.html?org_name=Verizon&employee_mode=1&employee_fname=Kevin&employee_lname=Thompson&lat=43.2672&lon=-70.8617](http://ocularwarfare.com/ipew/index.html?org_name=Verizon&employee_mode=1&employee_fname=Kevin&employee_lname=Thompson&lat=43.2672&lon=-70.8617)
 
 ### Using IPew
 

--- a/index.html
+++ b/index.html
@@ -406,8 +406,10 @@ function about() {
            }
            // blame a former employee
            else if (typeof employee_mode !== 'undefined') {
-             srclat = in_lat;
-             srclong = in_lon;
+             if (typeof in_lat !== 'undefined' && typeof in_lon !== 'undefined') {
+               srclat = in_lat;
+               srclong = in_lon;
+             }
              which_attack = "Former employee attack:" + employee_fname + " " + employee_lname;
              srccountry = "usa";
            }

--- a/index.html
+++ b/index.html
@@ -410,7 +410,10 @@ function about() {
                srclat = in_lat;
                srclong = in_lon;
              }
-             which_attack = "Former employee attack:" + employee_fname + " " + employee_lname;
+             which_attack = "Former employee attack"
+             if (typeof employee_fname !== 'undefined' && typeof employee_lname !== 'undefined') {
+               which_attack += ":" + employee_fname + " " + employee_lname;
+             }
              srccountry = "usa";
            }
 

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@ body {
 }
 
 #about {
-  display: hidden; 
+  display: hidden;
 }
 
 #aboutdiv {
@@ -188,6 +188,9 @@ function about() {
     var chatt_mode = $.getUrlVar('chatt_mode');
     var china_mode = $.getUrlVar('china_mode');
     var dprk_mode = $.getUrlVar('dprk_mode');
+    var employee_mode = $.getUrlVar('employee_mode');
+    var employee_fname = $.getUrlVar('employee_fname');
+    var employee_lname = $.getUrlVar('employee_lname');
     var origin = $.getUrlVar('origin');
     var random_mode = $.getUrlVar('random_mode');
     var tng = $.getUrlVar('tng');
@@ -215,7 +218,7 @@ function about() {
     }
 
     if (typeof org_name !== 'undefined') { $("#titlediv").text(decodeURI(org_name) + " IPew Attack Map").html() }
-    
+
     // we maintain a fixed queue of "attacks" via this class
     function FixedQueue( size, initialValues ){
       initialValues = (initialValues || []);
@@ -256,29 +259,29 @@ function about() {
     var rand = function(min, max) {
         return Math.random() * (max - min) + min;
     };
-     
+
     var getRandomCountry = function(countries, weight) {
 
         var total_weight = weight.reduce(function (prev, cur, i, arr) {
             return prev + cur;
         });
-         
+
         var random_num = rand(0, total_weight);
         var weight_sum = 0;
-         
+
         for (var i = 0; i < countries.length; i++) {
             weight_sum += weight[i];
             weight_sum = +weight_sum.toFixed(2);
-             
+
             if (random_num <= weight_sum) {
                 return countries[i];
             }
         }
-         
+
     };
 
     // need to make this dynamic since it's approximated from sources
-     
+
     var countries = [9,22,29,49,56,58,78,82,102,117,139,176,186] ;
     var weight = [0.000,0.001,0.004,0.008,0.009,0.037,0.181,0.002,0.000,0.415,0.006,0.075,0.088];
 
@@ -304,7 +307,7 @@ function about() {
           borderWidth: 0.75,
           borderColor: '#4393c3',
           popupTemplate: function(geography, data) {
-            return '<div class="hoverinfo" style="color:white;background:black">' + 
+            return '<div class="hoverinfo" style="color:white;background:black">' +
                    geography.properties.name + '</div>';
           },
           popupOnHover: true,
@@ -350,7 +353,7 @@ function about() {
        getData: function() {
 
            var self = this;
-           
+
            if (typeof random_mode !== 'undefined') { Math.floor((Math.random() * slatlong.length)); }
 
            dst = Math.floor((Math.random() * slatlong.length));
@@ -380,7 +383,7 @@ function about() {
            which_attack = attack_type[Math.floor((Math.random() * attack_type.length))];
            var srccountry = slatlong[src]["country"];
            // "Hi, Mandiant!!"
-           if (typeof china_mode !== 'undefined') { 
+           if (typeof china_mode !== 'undefined') {
              srclat = cnlatlong[src].lat;
              srclong = cnlatlong[src].long;
              if (cnlatlong[src].country=="chn") { which_attack = "ZOMGOSH CHINA!!!!!!"; }
@@ -399,6 +402,13 @@ function about() {
              srclat = 35.0456297;
              srclong = -85.30968;
              which_attack = "OMG NATION STATE CHATTANOOGA!!!";
+             srccountry = "usa";
+           }
+           // blame a former employee
+           else if (typeof employee_mode !== 'undefined') {
+             srclat = in_lat;
+             srclong = in_lon;
+             which_attack = "Former employee attack:" + employee_fname + " " + employee_lname;
              srccountry = "usa";
            }
 
@@ -471,7 +481,7 @@ function about() {
 
     </script>
     <!-- Piwik -->
-    <script type="text/javascript"> 
+    <script type="text/javascript">
       var _paq = _paq || [];
       _paq.push(['trackPageView']);
       _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
This PR adds a new mode to pewpew where you can make all the attacks come from a former employee. You specify `employee_mode=1` to activate employee mode. You can also specify `employee_fname=First&employee_lname=Last` to name the rogue former employee. Finally, you can use the `lat` and `lon` settings to make the attacks come from a particular location.