### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@ function about() {
   <br/>
   Check out the <a target=_blank href='http://github.com/hrbrmstr/pewpew'>github repository</a> for more information and instructions on how to customize the map options for maximum effect.<br/>
   <br/>
-  Brought to you by <a target=_blank href="http://twitter.com/alexcpsec">@alexcpsec</a>, <a target=_blank href="http://twitter.com/hrbrmstr">@hrbrmstr</a> &amp; <a target=_blank href="http://dds.ec/blog">Data-Driven Security</a>
+  Brought to you by <a target=_blank href="http://twitter.com/alexcpsec">@alexcpsec</a>, <a target=_blank href="http://twitter.com/hrbrmstr">@hrbrmstr</a> &amp; <a target=_blank href="https://datadrivensecurity.info/blog/pages/resources.html">Data Driven Security</a>
   </div>
 
   <!-- Use Hash-Bang to maintain scroll position when closing modal -->


### PR DESCRIPTION
correcting the URL in PewPew's About IPew text box such that the link for Data Driven Security points to https://datadrivensecurity.info/blog/pages/about-dds.html instead of some other site in Spain as it does now. 

Currently points to data drive security https://dds.ec is not the correct URL.